### PR TITLE
Optimization pass

### DIFF
--- a/MusicTypePatcher/MusicTypePatcher.csproj
+++ b/MusicTypePatcher/MusicTypePatcher.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Platforms>x64</Platforms>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mutagen.Bethesda" Version="0.41.0" />
-    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.25.4" />
+    <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.47.4" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.30.7" />
   </ItemGroup>
 
 </Project>

--- a/MusicTypePatcher/Patcher.cs
+++ b/MusicTypePatcher/Patcher.cs
@@ -64,12 +64,12 @@ namespace MusicTypePatcher
             copy.VersionControl = Timestamp;
             copy.Tracks = new ExtendedList<IFormLinkGetter<IMusicTrackGetter>>();
 
-            var originalTracks = origin.Tracks.EmptyIfNull();
-            int originalTrackCount = originalTracks.Count();
+            var originalTracks = origin.Tracks.EmptyIfNull().ToArray();
+            int originalTrackCount = originalTracks.Length;
 
-            var extentTracks = extentContexts.Select(static i => i.Record.Tracks.EmptyIfNull());
+            var extentTracks = extentContexts.Select(static i => i.Record.Tracks.EmptyIfNull().ToArray()).ToArray();
 
-            extentTracks.Aggregate(originalTracks, (i, k) => i.Intersection(k)).ForEach(copy.Tracks.Add);
+            extentTracks.Aggregate(originalTracks, (i, k) => i.Intersection(k).ToArray()).ForEach(copy.Tracks.Add);
             copy.Tracks.AddRange(extentTracks.SelectMany(i => i.DisjunctLeft(copy.Tracks)));
 
             Console.WriteLine("Copied {0} tracks to {1}", copy.Tracks.Count - originalTrackCount, copy.EditorID);


### PR DESCRIPTION
User reported a 3 hour runtime earlier today
![image](https://github.com/user-attachments/assets/ed8ad4cc-645b-49ca-aa79-6ccfeb3d8d49)

Did an optimization pass to try to help speed it up.  Let me know if you have any questions related to why any changes were made!

Definitely check that the logic still works as intended, as I'm not too familiar with its goals so I might've tweaked something undesirably